### PR TITLE
Fixups to COVID-19 doc

### DIFF
--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -77,7 +77,7 @@ To verify jobs are being routed appropriately,
 with `condor_ce_router_q`.
 
 !!! note "Additional considerations for older CEs"
-    Prior to HTCondor 8.8.8 or 8.9.5, HTCondor-CE had separate rules for handling
+    Prior to HTCondor 8.8.7 or 8.9.5, HTCondor-CE had separate rules for handling
     multiple routes; see the
     [job router recipes](/compute-element/job-router-recipes#how-jobs-match-to-job-routes) for more
     details.

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -79,7 +79,7 @@ with `condor_ce_router_q`.
 !!! note "Additional considerations for older CEs"
     Prior to HTCondor 8.8.8 or 8.9.5, HTCondor-CE had separate rules for handling
     multiple routes; see the
-    [job router recipes](/compute-element/job-router-recipes#how_jobs_match_to_job_routes) for more
+    [job router recipes](/compute-element/job-router-recipes#how-jobs-match-to-job-routes) for more
     details.
 
 Similarly, at a HTCondor site, one can place these jobs into a

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -51,7 +51,7 @@ JOB_ROUTER_ENTRIES @=jre
 To add a new route for COVID-19 pilots, append a new route
 prior to the existing one:
 
-```
+```hl_lines="2 3 4 5 6 7 8"
 JOB_ROUTER_ENTRIES @=jre
 [
  name = "OSG COVID-19 Jobs";

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -79,7 +79,7 @@ with `condor_ce_router_q`.
 !!! note "Additional considerations for older CEs"
     Prior to HTCondor 8.8.8 or 8.9.5, HTCondor-CE had separate rules for handling
     multiple routes; see the
-    [job router recipes](/compute-element/job-router-recipes) for more
+    [job router recipes](/compute-element/job-router-recipes#how_jobs_match_to_job_routes) for more
     details.
 
 Similarly, at a HTCondor site, one can place these jobs into a

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -41,7 +41,7 @@ system:
 ```
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG Jobs";
+ name = "OSG_Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  queue = "osg";
@@ -49,24 +49,27 @@ JOB_ROUTER_ENTRIES @=jre
 ```
 
 To add a new route for COVID-19 pilots, append a new route
-prior to the existing one:
+prior to the existing one and specify their order:
 
-```hl_lines="2 3 4 5 6 7 8"
+```hl_lines="2 3 4 5 6 7 8 17 18"
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG COVID-19 Jobs";
+ name = "OSG_COVID-19_Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  queue = "covid19";
  Requirements = (TARGET.IsCOVID19 =?= true);
 ]
 [
- name = "OSG Jobs";
+ name = "OSG_Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  queue = "osg";
 ]
 @jre
+
+# Specify the order of the routes
+JOB_ROUTER_ROUTE_NAMES = OSG_COVID-19_Jobs, OSG_Jobs
 ```
 
 To verify jobs are being routed appropriately,
@@ -74,7 +77,7 @@ To verify jobs are being routed appropriately,
 with `condor_ce_router_q`.
 
 !!! note "Additional considerations for older CEs"
-    Prior to HTCondor 8.7.1, HTCondor-CE had separate rules for handling
+    Prior to HTCondor 8.8.8 or 8.9.5, HTCondor-CE had separate rules for handling
     multiple routes; see the
     [job router recipes](/compute-element/job-router-recipes) for more
     details.
@@ -85,17 +88,20 @@ separate accounting group by providing the `set_AcctGroup` attribute:
 ```hl_lines="5 11"
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG COVID-19 Jobs";
+ name = "OSG_COVID-19_Jobs";
  TargetUniverse = 5;
  set_AcctGroup = "covid19";
  Requirements = (TARGET.IsCOVID19 =?= true);
 ]
 [
- name = "OSG Jobs";
+ name = "OSG_Jobs";
  TargetUniverse = 5;
  set_AcctGroup = "osg";
 ]
 @jre
+
+# Specify the order of the routes
+JOB_ROUTER_ROUTE_NAMES = OSG_COVID-19_Jobs, OSG_Jobs
 ```
 
 Only Supporting COVID-19
@@ -103,7 +109,7 @@ Only Supporting COVID-19
 
 If your resource _only_ wants to support COVID-19 research, then you need
 to [enable the OSG VO](/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin)
-but only provide the "OSG COVID-19 Jobs" job route above.  As long as the
+but only provide the `OSG_COVID-19_Jobs` job route above.  As long as the
 `Requirements` expression for your job route includes
 `(TARGET.IsCOVID19 =?= true)`, then non-COVID pilots will not be routed
 to the batch system.

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -82,19 +82,18 @@ with `condor_ce_router_q`.
 Similarly, at a HTCondor site, one can place these jobs into a
 separate accounting group by providing the `set_AcctGroup` attribute:
 
-```hl_lines="6"
+```hl_lines="5 11"
 JOB_ROUTER_ENTRIES @=jre
 [
  name = "OSG COVID-19 Jobs";
- GridResource = "batch slurm";
- TargetUniverse = 9;
+ TargetUniverse = 5;
  set_AcctGroup = "covid19";
  Requirements = (TARGET.IsCOVID19 =?= true);
 ]
 [
  name = "OSG Jobs";
  TargetUniverse = 5;
- queue = "osg";
+ set_AcctGroup = "osg";
 ]
 @jre
 ```

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -70,7 +70,7 @@ JOB_ROUTER_ENTRIES @=jre
 ```
 
 To verify jobs are being routed appropriately,
-[one may examine pilots](compute-element/troubleshoot-htcondor-ce/#condor_ce_router_q)
+[one may examine pilots](/compute-element/troubleshoot-htcondor-ce/#condor_ce_router_q)
 with `condor_ce_router_q`.
 
 !!! note "Additional considerations for older CEs"

--- a/docs/compute-element/job-router-recipes.md
+++ b/docs/compute-element/job-router-recipes.md
@@ -61,11 +61,11 @@ If the job meets the requirements of multiple routes,  the route that is chosen 
 | If your version of HTCondor is...          | Then the route is chosen by...                                                                                                                                                                                   |
 |--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | < 8.7.1                                    | **Round-robin** between all matching routes. In this case, we recommend making each route's requirements mutually exclusive.                                                                                     |
-| >= 8.7.1 and < 8.8.6, >= 8.9.0 and < 8.9.5 | **First matching route** where routes are considered in hash-table order. In this case, we recommend making each route's requirements mutually exclusive.                                                        |
-| >= 8.8.6, >= 8.9.5                         | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/latest/admin-manual/configuration-macros.html#JOB_ROUTER_ROUTE_NAMES) |
+| >= 8.7.1 and < 8.8.7, >= 8.9.0 and < 8.9.5 | **First matching route** where routes are considered in hash-table order. In this case, we recommend making each route's requirements mutually exclusive.                                                        |
+| >= 8.8.7, >= 8.9.5                         | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/latest/admin-manual/configuration-macros.html#JOB_ROUTER_ROUTE_NAMES) |
 
 !!! bug "Job Route Order"
-    For HTCondor versions < 8.8.6 (as well as versions >= 8.9.0 and < 8.9.5) the order of job routes does not match the
+    For HTCondor versions < 8.8.7 (as well as versions >= 8.9.0 and < 8.9.5) the order of job routes does not match the
     order in which they are configured.
     As a result, we recommend updating to at least HTCondor 8.9.5 (or 8.8.6) and specifying the names of your routes in
     `JOB_ROUTER_ROUTE_NAMES` in the order that you'd like them considered.

--- a/docs/compute-element/job-router-recipes.md
+++ b/docs/compute-element/job-router-recipes.md
@@ -58,10 +58,17 @@ If the job only meets one route's requirements, the job is matched to that route
 If the job meets the requirements of multiple routes,  the route that is chosen depends on your version of HTCondor
 (`condor_version`):
 
-| If your version of HTCondor is... | Then the route is chosen by...                                                                                               |
-|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| < 8.7.1                           | **Round-robin** between all matching routes. In this case, we recommend making each route's requirements mutually exclusive. |
-| >= 8.7.1                          | **First matching route** where routes are considered in the same order that they are configured                              |
+| If your version of HTCondor is...          | Then the route is chosen by...                                                                                                                                                                                   |
+|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| < 8.7.1                                    | **Round-robin** between all matching routes. In this case, we recommend making each route's requirements mutually exclusive.                                                                                     |
+| >= 8.7.1 and < 8.8.6, >= 8.9.0 and < 8.9.5 | **First matching route** where routes are considered in hash-table order. In this case, we recommend making each route's requirements mutually exclusive.                                                        |
+| >= 8.8.6, >= 8.9.5                         | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/latest/admin-manual/configuration-macros.html#JOB_ROUTER_ROUTE_NAMES) |
+
+!!! bug "Job Route Order"
+    For HTCondor versions < 8.8.6 (as well as versions >= 8.9.0 and < 8.9.5) the order of job routes does not match the
+    order in which they are configured.
+    As a result, we recommend updating to at least HTCondor 8.9.5 (or 8.8.6) and specifying the names of your routes in
+    `JOB_ROUTER_ROUTE_NAMES` in the order that you'd like them considered.
 
 If you're using HTCondor >= 8.7.1 and would like to use round-robin matching, add the following text to a file in
 `/etc/condor-ce/config.d/`:


### PR DESCRIPTION
Are are we going to treat sites that only want COVID-19 jobs differently at the factory? Because otherwise I've got a commit elaborating on the config and explaining that they'll see held jobs due to other OSG jobs not matching